### PR TITLE
Fix/Use f32 for Point and Vector data

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,13 +1,12 @@
 use geometry::types::{Point, Vector};
 use physics::types::{Body, Field};
-use std::i32;
 
 //////////////////////////////////////////////////////////////////////////////
 
 #[repr(C)]
 pub struct NewtonPoint {
-    pub x: i32,
-    pub y: i32,
+    pub x: f32,
+    pub y: f32,
 }
 
 impl NewtonPoint {
@@ -21,10 +20,10 @@ impl NewtonPoint {
 
 #[no_mangle]
 pub extern "C" fn newton_new_field(
-    g: f64,
-    solar_mass: f64,
-    min_dist: f64,
-    max_dist: f64,
+    g: f32,
+    solar_mass: f32,
+    min_dist: f32,
+    max_dist: f32,
 ) -> *mut Field {
     let field = Field::new(g, solar_mass, min_dist, max_dist);
     let boxed = Box::new(field);
@@ -40,11 +39,11 @@ pub unsafe extern "C" fn newton_destroy_field(field: *mut Field) {
 pub unsafe extern "C" fn newton_add_body(
     field: *mut Field,
     id: u32,
-    mass: f64,
-    x: i32,
-    y: i32,
-    dx: f64,
-    dy: f64,
+    mass: f32,
+    x: f32,
+    y: f32,
+    dx: f32,
+    dy: f32,
 ) {
     let body = Body::new(id, mass, Point { x, y }, Vector { dx, dy });
     let field = &mut *field;
@@ -55,9 +54,9 @@ pub unsafe extern "C" fn newton_add_body(
 pub unsafe extern "C" fn newton_distribute_bodies(
     field: *mut Field,
     num_bodies: u32,
-    min_dist: u32,
-    max_dist: u32,
-    dy: f64,
+    min_dist: f32,
+    max_dist: f32,
+    dy: f32,
 ) {
     let distributor = ::geometry::util::Distributor {
         num_bodies,
@@ -83,8 +82,8 @@ pub unsafe extern "C" fn newton_body_pos(field: *const Field, id: u32) -> Newton
     match field.bodies.get(&id) {
         Some(val) => NewtonPoint::from(&((val as &Body).position)),
         None => NewtonPoint {
-            x: 0,
-            y: 0,
+            x: 0.0,
+            y: 0.0,
         },
     }
 }

--- a/src/geometry/types.rs
+++ b/src/geometry/types.rs
@@ -6,20 +6,20 @@ use std::ops::{Add, AddAssign, Div, Mul};
 
 #[derive(PartialEq, Debug)]
 pub struct Point {
-    pub x: i32,
-    pub y: i32,
+    pub x: f32,
+    pub y: f32,
 }
 
 impl Point {
     pub fn origin() -> Point {
-        Point { x: 0, y: 0 }
+        Point { x: 0.0, y: 0.0 }
     }
 
     pub fn is_origin(&self) -> bool {
         self == &Point::origin()
     }
 
-    pub fn distance_to(&self, other: &Point) -> f64 {
+    pub fn distance_to(&self, other: &Point) -> f32 {
         let difference = Vector::difference(self, other);
         difference.magnitude()
     }
@@ -31,8 +31,8 @@ impl Point {
 
 #[derive(Debug)]
 pub struct Vector {
-    pub dx: f64,
-    pub dy: f64,
+    pub dx: f32,
+    pub dy: f32,
 }
 
 impl PartialEq for Vector {
@@ -62,10 +62,10 @@ impl AddAssign for Vector {
     }
 }
 
-impl<'a> Mul<f64> for &'a Vector {
+impl<'a> Mul<f32> for &'a Vector {
     type Output = Vector;
 
-    fn mul(self, scalar: f64) -> Self::Output {
+    fn mul(self, scalar: f32) -> Self::Output {
         Vector {
             dx: self.dx * scalar,
             dy: self.dy * scalar,
@@ -73,10 +73,10 @@ impl<'a> Mul<f64> for &'a Vector {
     }
 }
 
-impl<'a> Div<f64> for &'a Vector {
+impl<'a> Div<f32> for &'a Vector {
     type Output = Vector;
 
-    fn div(self, scalar: f64) -> Self::Output {
+    fn div(self, scalar: f32) -> Self::Output {
         Vector {
             dx: self.dx / scalar,
             dy: self.dy / scalar,
@@ -85,7 +85,7 @@ impl<'a> Div<f64> for &'a Vector {
 }
 
 impl<'a> Mul for &'a Vector {
-    type Output = f64;
+    type Output = f32;
 
     fn mul(self, rhs: &Vector) -> Self::Output {
         self.dx * rhs.dx + self.dy * rhs.dy
@@ -99,13 +99,13 @@ impl Vector {
 
     pub fn difference(lhs: &Point, rhs: &Point) -> Vector {
         Vector {
-            dx: (lhs.x - rhs.x) as f64,
-            dy: (lhs.y - rhs.y) as f64,
+            dx: (lhs.x - rhs.x),
+            dy: (lhs.y - rhs.y),
         }
     }
 
-    pub fn magnitude(&self) -> f64 {
-        ((self.dx * self.dx + self.dy * self.dy) as f64).sqrt()
+    pub fn magnitude(&self) -> f32 {
+        (self.dx * self.dx + self.dy * self.dy).sqrt()
     }
 
     pub fn normalized(&self) -> Option<Vector> {
@@ -130,8 +130,8 @@ mod tests {
     #[test]
     fn point_distance_from_origin() {
         // given
-        let p1 = Point { x: 0, y: 0 };
-        let p2 = Point { x: 5, y: 0 };
+        let p1 = Point { x: 0.0, y: 0.0 };
+        let p2 = Point { x: 5.0, y: 0.0 };
 
         // when
         let result = p1.distance_to(&p2);
@@ -143,8 +143,8 @@ mod tests {
     #[test]
     fn point_distance_to_origin() {
         // given
-        let p1 = Point { x: 0, y: 0 };
-        let p2 = Point { x: 0, y: -5 };
+        let p1 = Point { x: 0.0, y: 0.0 };
+        let p2 = Point { x: 0.0, y: -5.0 };
 
         // when
         let result = p2.distance_to(&p1);
@@ -201,7 +201,7 @@ mod tests {
         let result = &a * &b;
 
         // then
-        assert!((result - 3.13).abs() < 0.0000001);
+        assert!((result - 3.13).abs() < 0.00001);
     }
 
     #[test]

--- a/src/geometry/util.rs
+++ b/src/geometry/util.rs
@@ -1,7 +1,7 @@
 use geometry::types::{Point, Vector};
 use physics::types::Body;
 use rand::prelude::*;
-use std::f64::consts::PI;
+use std::f32::consts::PI;
 use std::ops::Mul;
 use std::collections::HashMap;
 
@@ -21,7 +21,7 @@ impl<'a> Mul<Vector> for &'a Transformation {
 }
 
 impl Transformation {
-    pub fn rotation(radians: f64) -> Transformation {
+    pub fn rotation(radians: f32) -> Transformation {
         let (sin, cos) = radians.sin_cos();
         Transformation(Vector { dx: cos, dy: sin }, Vector { dx: -sin, dy: cos })
     }
@@ -34,9 +34,9 @@ impl Transformation {
 
 pub struct Distributor {
     pub num_bodies: u32,
-    pub min_dist: u32,
-    pub max_dist: u32,
-    pub dy: f64,
+    pub min_dist: f32,
+    pub max_dist: f32,
+    pub dy: f32,
 }
 
 impl Distributor {
@@ -51,7 +51,7 @@ impl Distributor {
 
             let trans = Transformation::rotation(angle);
             let position = &trans * Vector {
-                dx: dist as f64,
+                dx: dist,
                 dy: 0.0,
             };
 
@@ -61,8 +61,8 @@ impl Distributor {
             };
 
             let pos = Point {
-                x: position.dx as i32,
-                y: position.dy as i32,
+                x: position.dx,
+                y: position.dy,
             };
 
             let body = Body::new(i, 0.1, pos, velocity);
@@ -79,7 +79,7 @@ impl Distributor {
 mod tests {
     use super::*;
     use geometry::types::Vector;
-    use std::f64::consts::FRAC_PI_2;
+    use std::f32::consts::FRAC_PI_2;
 
     #[test]
     fn it_transforms_a_vector() {

--- a/src/newton.h
+++ b/src/newton.h
@@ -12,8 +12,8 @@
  *  point data.
  */
 struct NewtonPoint {
-    int32_t x;
-    int32_t y;
+    float x;
+    float y;
 };
 
 /**
@@ -26,7 +26,7 @@ struct field;
  *  Allocates a new field instance with the given gravitational
  *  constant, solar mass, min and max effective distance.
  */
-struct field *newton_new_field(double g, double solar_mass, double min_dist, double max_dist);
+struct field *newton_new_field(float g, float solar_mass, float min_dist, float max_dist);
 
 /**
  *  Destroys the field instance referred
@@ -39,14 +39,14 @@ void newton_destroy_field(struct field *field);
  *  given properties (id, mass, position, velocity)
  *  and adds it to the field.
  */
-void newton_add_body(struct field *field, uint32_t id, double mass, int32_t x, int32_t y, double dx, double dy);
+void newton_add_body(struct field *field, uint32_t id, float mass, float x, float y, float dx, float dy);
 
 /**
  *  Generates a radial distribution of num_bodies between
  *  min_dist and max_dist from a central point. These are
  *  assigned to the field.
  */
-void newton_distribute_bodies(struct field *field, uint32_t num_bodies, uint32_t min_dist, uint32_t max_dist, double dy);
+void newton_distribute_bodies(struct field *field, uint32_t num_bodies, float min_dist, float max_dist, float dy);
 
  /**
   *  Advances the field state by a single step.

--- a/src/physics/types.rs
+++ b/src/physics/types.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub struct Body {
     pub id: u32,
-    pub mass: f64,
+    pub mass: f32,
     pub position: Point,
     pub velocity: Vector,
 }
@@ -24,7 +24,7 @@ impl PartialEq for Body {
 }
 
 impl Body {
-    pub fn new(id: u32, mass: f64, position: Point, velocity: Vector) -> Body {
+    pub fn new(id: u32, mass: f32, position: Point, velocity: Vector) -> Body {
         if mass <= 0.0 {
             panic!("A body's mass must be greater than 0. Got {}", mass);
         }
@@ -38,8 +38,8 @@ impl Body {
 
     pub fn apply_force(&mut self, force: &Vector) {
         self.velocity += force / self.mass;
-        self.position.x += self.velocity.dx.round() as i32;
-        self.position.y += self.velocity.dy.round() as i32;
+        self.position.x += self.velocity.dx;
+        self.position.y += self.velocity.dy;
     }
 }
 
@@ -49,15 +49,15 @@ impl Body {
 // gravitational force.
 
 pub struct Field {
-    pub g: f64,
-    pub min_dist: f64,
-    pub max_dist: f64,
+    pub g: f32,
+    pub min_dist: f32,
+    pub max_dist: f32,
     pub bodies: HashMap<u32, Body>,
     sun: Option<Body>,
 }
 
 impl Field {
-    pub fn new(g: f64, solar_mass: f64, min_dist: f64, max_dist: f64) -> Field {
+    pub fn new(g: f32, solar_mass: f32, min_dist: f32, max_dist: f32) -> Field {
         let sun = match solar_mass {
             // TODO: tidy this up
             x if x > 0.0 => Some(Body::new(0, solar_mass, Point::origin(), Vector::zero())),
@@ -130,7 +130,7 @@ impl Field {
         }
 
         let difference = Vector::difference(&b2.position, &b1.position);
-        let distance = difference.magnitude().min(self.max_dist).max(self.min_dist);
+        let distance = difference.magnitude().max(self.min_dist);
         let force = (self.g * b1.mass * b2.mass) / (distance * distance);
 
         let direction = match difference.normalized() {
@@ -169,14 +169,14 @@ mod tests {
         let b1 = Body {
             id: 0,
             mass: 1.0,
-            position: Point { x: 1, y: 2 },
+            position: Point { x: 1.0, y: 2.0 },
             velocity: Vector::zero(),
         };
 
         let b2 = Body {
             id: 0,
             mass: 1.0,
-            position: Point { x: 1, y: 2 },
+            position: Point { x: 1.0, y: 2.0 },
             velocity: Vector::zero(),
         };
 
@@ -191,17 +191,17 @@ mod tests {
         let mut sut = Body {
             id: 0,
             mass: 2.0,
-            position: Point { x: 1, y: 2 },
+            position: Point { x: 1.0, y: 2.0 },
             velocity: Vector { dx: -2.0, dy: 5.0 },
         };
 
-        let force = Vector { dx: 2.6, dy: -3.2 };
+        let force = Vector { dx: 3.0, dy: -3.0 };
 
         // when
         sut.apply_force(&force);
 
         // then
-        assert_eq!(sut.velocity, Vector { dx: -0.7, dy: 3.4 });
-        assert_eq!(sut.position, Point { x: 0, y: 5 });
+        assert_eq!(sut.velocity, Vector { dx: -0.5, dy: 3.5 });
+        assert_eq!(sut.position, Point { x: 0.5, y: 5.5 });
     }
 }


### PR DESCRIPTION
# What's in this PR?

## Issues
A `Body` object stores its position data using `i32` but its velocity data as `f64`. This means requires not only some ugly casting, but also loss of data as a result of that casting. This is most evident when updating a body's position with a very small velocity. Since the velocity is rounded before casting, it could happen that the velocity is equivalent to zero, and so the body wouldn't change its position.

## Solutions
This can all be avoided by simply unifying the data type used for coordinates, since we would no longer need to cast nor round up/down. A small velocity applied repeatedly would eventually accumulate enough to be visible as a change in body position. It's worth noting that initially the `i32` type was selected to represent Point data because they were suppose to represent pixel data. Although we now will use floating point values, we don't actually need `f64` types since we don't expect to have such minuscule or enormous positions/velocities. On the other hand, we do expect to have a large number of bodies in the simulation Using `f32` instead of `f64` would potentially save significant memory.