### PR TITLE
fix/field trait

### DIFF
--- a/src/geometry/util.rs
+++ b/src/geometry/util.rs
@@ -44,7 +44,7 @@ impl Distributor {
         let mut angle_rand = thread_rng();
         let mut dist_rand = thread_rng();
 
-        for i in 0..self.num_bodies {
+        for _ in 0..self.num_bodies {
             let angle = angle_rand.gen_range(0.0, 2.0 * PI);
             let dist = dist_rand.gen_range(self.min_dist, self.max_dist);
 
@@ -64,7 +64,7 @@ impl Distributor {
                 y: position.dy,
             };
 
-            let body = Body::new(i, 0.1, pos, velocity);
+            let body = Body::new(0.1, pos, velocity);
             result.push(body);
         }
 

--- a/src/geometry/util.rs
+++ b/src/geometry/util.rs
@@ -3,7 +3,6 @@ use physics::types::Body;
 use rand::prelude::*;
 use std::f32::consts::PI;
 use std::ops::Mul;
-use std::collections::HashMap;
 
 // Transformation ////////////////////////////////////////////////////////////
 //
@@ -40,8 +39,8 @@ pub struct Distributor {
 }
 
 impl Distributor {
-    pub fn distribution(&self) -> HashMap<u32, Body> {
-        let mut result: HashMap<u32, Body> = HashMap::new();
+    pub fn distribution(&self) -> Vec<Body> {
+        let mut result: Vec<Body> = vec![];
         let mut angle_rand = thread_rng();
         let mut dist_rand = thread_rng();
 
@@ -66,7 +65,7 @@ impl Distributor {
             };
 
             let body = Body::new(i, 0.1, pos, velocity);
-            result.insert(i, body);
+            result.push(body);
         }
 
         result

--- a/src/newton.h
+++ b/src/newton.h
@@ -7,56 +7,34 @@
 
 #include <stdint.h>
 
-/**
- *  A simple wrapper struct to encapsulate
- *  point data.
- */
+// A simple wrapper struct to encapsulate point data.
 struct NewtonPoint {
     float x;
     float y;
 };
 
-/**
- *  A opaque struct representing the
- *  gravitational field.
- */
-struct field;
+// An opaque struct representing the environment.
+//
+struct environment;
 
-/**
- *  Allocates a new field instance with the given gravitational
- *  constant, solar mass, min and max effective distance.
- */
-struct field *newton_new_field(float g, float solar_mass, float min_dist, float max_dist);
+// Allocates a new Environment instance.
+//
+struct environment *newton_new_environment();
 
-/**
- *  Destroys the field instance referred
- *  to by the given pointer.
- */
-void newton_destroy_field(struct field *field);
+// Destroys the Environment instance referred to by the given pointer.
+//
+void newton_destroy_environment(struct environment *environment);
 
-/**
- *  Creates a new body instance with the
- *  given properties (id, mass, position, velocity)
- *  and adds it to the field.
- */
-void newton_add_body(struct field *field, uint32_t id, float mass, float x, float y, float dx, float dy);
+// Generates a radial distribution of bodies around a central point.
+//
+void newton_distribute_bodies(struct environment *environment, uint32_t num_bodies, float min_dist, float max_dist, float dy);
 
-/**
- *  Generates a radial distribution of num_bodies between
- *  min_dist and max_dist from a central point. These are
- *  assigned to the field.
- */
-void newton_distribute_bodies(struct field *field, uint32_t num_bodies, float min_dist, float max_dist, float dy);
+// Advances teh field state by a single step.
+//
+void newton_step(struct environment *environment);
 
- /**
-  *  Advances the field state by a single step.
-  */
- void newton_step(struct field *field);
-
- /**
-  *  Returns the coordinate of the body with the
-  *  given id, if it exists, else the origin.
-  */
-struct NewtonPoint newton_body_pos(const struct field *field, uint32_t id);
+// Returns the coordinates of the body with the given ID, if it exists,
+// else the origin is returned.
+struct NewtonPoint newton_body_pos(const struct environment *environment, uint32_t id);
 
 #endif //NEWTON_NEWTON_H

--- a/src/physics/force.rs
+++ b/src/physics/force.rs
@@ -12,6 +12,10 @@ pub struct Gravity {
 
 impl Gravity {
     pub fn new(g: f32, min_dist: f32) -> Gravity {
+        if min_dist <= 0.0 {
+            panic!("The minimum gravitational distance \
+            must be greater than 0. Got {}", min_dist);
+        }
         Gravity {
             g,
             min_dist,
@@ -65,6 +69,13 @@ impl Attractor {
 mod tests {
     use super::{Gravity, Attractor, Body};
     use geometry::types::{Point, Vector};
+
+    #[test]
+    #[should_panic(expected = "The minimum gravitational distance must be greater than 0.")]
+    fn gravity_with_negative_minimum_distance() {
+        // given
+        Gravity::new(1.0, -2.0);
+    }
 
     #[test]
     fn gravity_calculates_force() {

--- a/src/physics/force.rs
+++ b/src/physics/force.rs
@@ -61,3 +61,92 @@ impl Attractor {
         self.gravity.between(body, &self.body)
     }
 }
+
+// Tests /////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::{Gravity, Body};
+    use geometry::types::{Point, Vector};
+
+    #[test]
+    fn gravity_calculates_force() {
+        // given
+        let sut = Gravity::new(1.5, 4.0);
+
+        let b1 = Body::new(
+            0,
+            1.0,
+            Point { x: 1.0, y: 2.0},
+            Vector::zero()
+        );
+
+        let b2 = Body::new(
+            1,
+            2.0,
+            Point { x: -3.5, y: 0.0},
+            Vector::zero()
+        );
+
+        // when
+        let result = sut.between(&b1, &b2);
+
+        // then
+        assert_eq!(result, Vector { dx: -0.1130488514, dy: -0.0502439339});
+    }
+
+    #[test]
+    fn gravity_obeys_minimum_distance() {
+        // given
+        let sut = Gravity::new(1.5, 4.0);
+
+        let b1 = Body::new(
+            0,
+            1.0,
+            Point { x: 1.0, y: 2.0},
+            Vector::zero()
+        );
+
+        let b2 = Body::new(
+            1,
+            2.0,
+            Point { x: 2.0, y: 2.5},
+            Vector::zero()
+        );
+
+        assert!(b1.position.distance_to(&b2.position) < 4.0);
+
+        // when
+        let result = sut.between(&b1, &b2);
+
+        // then
+        let result_if_dist_was_4 = Vector { dx: 0.1677050983, dy: 0.0838525491};
+        assert_eq!(result, result_if_dist_was_4);
+    }
+
+    #[test]
+    fn gravity_is_undefined_for_bodies_with_equal_position() {
+        // given
+        let sut = Gravity::new(1.5, 4.0);
+
+        let b1 = Body::new(
+            0,
+            1.0,
+            Point { x: 1.0, y: 2.0},
+            Vector::zero()
+        );
+
+        let b2 = Body::new(
+            1,
+            2.0,
+            Point { x: 1.0, y: 2.0},
+            Vector::zero()
+        );
+
+        // when
+        let result = sut.between(&b1, &b2);
+
+        // then
+        assert_eq!(result, Vector::zero());
+    }
+}

--- a/src/physics/force.rs
+++ b/src/physics/force.rs
@@ -1,5 +1,5 @@
 use super::types::Body;
-use geometry::types::Vector;
+use geometry::types::{Point, Vector};
 
 // Gravity ///////////////////////////////////////////////////////////////////
 //
@@ -35,5 +35,28 @@ impl Gravity {
         };
 
         &direction * force
+    }
+}
+
+// Attractor /////////////////////////////////////////////////////////////////
+//
+// Gravitational attraction to a point.
+
+// TODO: Needs testing
+pub struct Attractor {
+    body: Body,
+    gravity: Gravity,
+}
+
+impl Attractor {
+    pub fn new(mass: f32, point: Point, g: f32, min_dist: f32) -> Attractor {
+        Attractor {
+            body: Body::new(0, mass, point, Vector::zero()),
+            gravity: Gravity::new(g, min_dist),
+        }
+    }
+
+    pub fn force(&self, body: &Body) -> Vector {
+        self.gravity.between(body, &self.body)
     }
 }

--- a/src/physics/force.rs
+++ b/src/physics/force.rs
@@ -51,6 +51,7 @@ pub struct Attractor {
 impl Attractor {
     pub fn new(mass: f32, point: Point, g: f32, min_dist: f32) -> Attractor {
         Attractor {
+            // TODO: remove id from body?
             body: Body::new(0, mass, point, Vector::zero()),
             gravity: Gravity::new(g, min_dist),
         }

--- a/src/physics/force.rs
+++ b/src/physics/force.rs
@@ -1,0 +1,39 @@
+use super::types::Body;
+use geometry::types::Vector;
+
+// Gravity ///////////////////////////////////////////////////////////////////
+//
+// Newton's Law of Universal Gravitation.
+
+// TODO: Needs testing
+pub struct Gravity {
+    g: f32,
+    min_dist: f32,
+}
+
+impl Gravity {
+    pub fn new(g: f32, min_dist: f32) -> Gravity {
+        Gravity {
+            g,
+            min_dist,
+        }
+    }
+
+    pub fn between(&self, b1: &Body, b2: &Body) -> Vector {
+        // Force is undefined for two bodies that occupy the same space.
+        if b1.position == b2.position {
+            return Vector::zero();
+        }
+
+        let difference = Vector::difference(&b2.position, &b1.position);
+        let distance = difference.magnitude().max(self.min_dist);
+        let force = (self.g * b1.mass * b2.mass) / (distance * distance);
+
+        let direction = match difference.normalized() {
+            None => Vector::zero(),
+            Some(normalized) => normalized,
+        };
+
+        &direction * force
+    }
+}

--- a/src/physics/force.rs
+++ b/src/physics/force.rs
@@ -49,8 +49,7 @@ pub struct Attractor {
 impl Attractor {
     pub fn new(mass: f32, point: Point, g: f32, min_dist: f32) -> Attractor {
         Attractor {
-            // TODO: remove id from body?
-            body: Body::new(0, mass, point, Vector::zero()),
+            body: Body::new(mass, point, Vector::zero()),
             gravity: Gravity::new(g, min_dist),
         }
     }
@@ -73,14 +72,12 @@ mod tests {
         let sut = Gravity::new(1.5, 4.0);
 
         let b1 = Body::new(
-            0,
             1.0,
             Point { x: 1.0, y: 2.0},
             Vector::zero()
         );
 
         let b2 = Body::new(
-            1,
             2.0,
             Point { x: -3.5, y: 0.0},
             Vector::zero()
@@ -99,14 +96,12 @@ mod tests {
         let sut = Gravity::new(1.5, 4.0);
 
         let b1 = Body::new(
-            0,
             1.0,
             Point { x: 1.0, y: 2.0},
             Vector::zero()
         );
 
         let b2 = Body::new(
-            1,
             2.0,
             Point { x: 2.0, y: 2.5},
             Vector::zero()
@@ -128,14 +123,12 @@ mod tests {
         let sut = Gravity::new(1.5, 4.0);
 
         let b1 = Body::new(
-            0,
             1.0,
             Point { x: 1.0, y: 2.0},
             Vector::zero()
         );
 
         let b2 = Body::new(
-            1,
             2.0,
             Point { x: 1.0, y: 2.0},
             Vector::zero()
@@ -159,7 +152,6 @@ mod tests {
         );
 
         let body = Body::new(
-            0,
             3.8,
             Point { x: 1.0, y: 2.0},
             Vector::zero()

--- a/src/physics/force.rs
+++ b/src/physics/force.rs
@@ -5,7 +5,6 @@ use geometry::types::{Point, Vector};
 //
 // Newton's Law of Universal Gravitation.
 
-// TODO: Needs testing
 pub struct Gravity {
     g: f32,
     min_dist: f32,
@@ -42,7 +41,6 @@ impl Gravity {
 //
 // Gravitational attraction to a point.
 
-// TODO: Needs testing
 pub struct Attractor {
     body: Body,
     gravity: Gravity,
@@ -66,7 +64,7 @@ impl Attractor {
 
 #[cfg(test)]
 mod tests {
-    use super::{Gravity, Body};
+    use super::{Gravity, Attractor, Body};
     use geometry::types::{Point, Vector};
 
     #[test]
@@ -148,5 +146,29 @@ mod tests {
 
         // then
         assert_eq!(result, Vector::zero());
+    }
+
+    #[test]
+    fn attractor_calculates_force() {
+        // given
+        let sut = Attractor::new(
+            100.0,
+            Point::origin(),
+            2.3,
+            1.0
+        );
+
+        let body = Body::new(
+            0,
+            3.8,
+            Point { x: 1.0, y: 2.0},
+            Vector::zero()
+        );
+
+        // when
+        let result = sut.force(&body);
+
+        // then
+        assert_eq!(result, Vector { dx: -78.17293649, dy: -156.345873});
     }
 }

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -1,1 +1,2 @@
 pub mod types;
+pub mod force;

--- a/src/physics/types.rs
+++ b/src/physics/types.rs
@@ -37,7 +37,6 @@ impl Environment {
 
 #[derive(Debug)]
 pub struct Body {
-    pub id: u32,
     pub mass: f32,
     pub position: Point,
     pub velocity: Vector,
@@ -53,12 +52,11 @@ impl PartialEq for Body {
 }
 
 impl Body {
-    pub fn new(id: u32, mass: f32, position: Point, velocity: Vector) -> Body {
+    pub fn new(mass: f32, position: Point, velocity: Vector) -> Body {
         if mass <= 0.0 {
             panic!("A body's mass must be greater than 0. Got {}", mass);
         }
         Body {
-            id,
             mass,
             position,
             velocity,
@@ -133,28 +131,26 @@ mod tests {
     #[should_panic(expected = "A body's mass must be greater than 0.")]
     fn body_with_zero_mass() {
         // given
-        Body::new(0, 0.0, Point::origin(), Vector::zero());
+        Body::new(0.0, Point::origin(), Vector::zero());
     }
 
     #[test]
     #[should_panic(expected = "A body's mass must be greater than 0.")]
     fn body_with_negative_mass() {
         // given
-        Body::new(0, -10.0, Point::origin(), Vector::zero());
+        Body::new(-10.0, Point::origin(), Vector::zero());
     }
 
     #[test]
     fn body_has_referential_equivalence() {
         // given
         let b1 = Body {
-            id: 0,
             mass: 1.0,
             position: Point { x: 1.0, y: 2.0 },
             velocity: Vector::zero(),
         };
 
         let b2 = Body {
-            id: 0,
             mass: 1.0,
             position: Point { x: 1.0, y: 2.0 },
             velocity: Vector::zero(),
@@ -169,7 +165,6 @@ mod tests {
     fn body_applies_force() {
         // given
         let mut sut = Body {
-            id: 0,
             mass: 2.0,
             position: Point { x: 1.0, y: 2.0 },
             velocity: Vector { dx: -2.0, dy: 5.0 },

--- a/src/physics/types.rs
+++ b/src/physics/types.rs
@@ -127,15 +127,18 @@ impl Field for BruteForceField {
 // Environment ///////////////////////////////////////////////////////////////
 
 pub struct Environment {
-    pub bodies: HashMap<u32, Body>,
+    pub bodies: Vec<Body>,
     pub fields: Vec<Box<Field>>,
 }
 
 impl Environment {
     pub fn update(&mut self) {
-        // update each field
-        for field in self.fields.iter_mut() {
-            field.update();
+        for field in self.fields.iter() {
+            let forces = field.forces(&self.bodies[..]);
+
+            for (body, force) in self.bodies.iter_mut().zip(forces.iter()) {
+                body.apply_force(force);
+            }
         }
     }
 }

--- a/src/physics/types.rs
+++ b/src/physics/types.rs
@@ -125,6 +125,8 @@ impl Field for BruteForceField {
 }
 
 // Environment ///////////////////////////////////////////////////////////////
+//
+// An environment represents a space in which bodies interact with fields.
 
 pub struct Environment {
     pub bodies: Vec<Body>,

--- a/src/physics/types.rs
+++ b/src/physics/types.rs
@@ -2,6 +2,35 @@ use geometry::types::{Point, Vector};
 use super::force::{Gravity, Attractor};
 use std::cmp::Eq;
 
+// Environment ///////////////////////////////////////////////////////////////
+//
+// An environment represents a space in which bodies interact with fields.
+
+pub struct Environment {
+    pub bodies: Vec<Body>,
+    pub fields: Vec<Box<Field>>,
+}
+
+impl Environment {
+    pub fn new() -> Environment {
+        let field = BruteForceField::new();
+        Environment {
+            bodies: vec![],
+            fields: vec![Box::from(field)],
+        }
+    }
+
+    pub fn update(&mut self) {
+        for field in self.fields.iter() {
+            let forces = field.forces(&self.bodies[..]);
+
+            for (body, force) in self.bodies.iter_mut().zip(forces.iter()) {
+                body.apply_force(force);
+            }
+        }
+    }
+}
+
 // Body //////////////////////////////////////////////////////////////////////
 //
 // A body represents a movable object in space.
@@ -53,20 +82,13 @@ pub trait Field {
 }
 
 // BruteForceField ///////////////////////////////////////////////////////////
+//
+// Brute force gravitation calculation between n bodies. For every body,
+// calculate the gravitational force with every other body directly.
 
 pub struct BruteForceField {
     force: Gravity,
     sun: Option<Attractor>,
-}
-
-impl BruteForceField {
-    pub fn new() -> BruteForceField {
-
-        BruteForceField {
-            force: Gravity::new(1.0, 4.0),
-            sun: Some(Attractor::new(10000.0, Point::origin(), 1.0, 4.0)),
-        }
-    }
 }
 
 impl Field for BruteForceField {
@@ -91,31 +113,11 @@ impl Field for BruteForceField {
     }
 }
 
-// Environment ///////////////////////////////////////////////////////////////
-//
-// An environment represents a space in which bodies interact with fields.
-
-pub struct Environment {
-    pub bodies: Vec<Body>,
-    pub fields: Vec<Box<Field>>,
-}
-
-impl Environment {
-    pub fn new() -> Environment {
-        let field = BruteForceField::new();
-        Environment {
-            bodies: vec![],
-            fields: vec![Box::from(field)],
-        }
-    }
-
-    pub fn update(&mut self) {
-        for field in self.fields.iter() {
-            let forces = field.forces(&self.bodies[..]);
-
-            for (body, force) in self.bodies.iter_mut().zip(forces.iter()) {
-                body.apply_force(force);
-            }
+impl BruteForceField {
+    pub fn new() -> BruteForceField {
+        BruteForceField {
+            force: Gravity::new(1.0, 4.0),
+            sun: Some(Attractor::new(10000.0, Point::origin(), 1.0, 4.0)),
         }
     }
 }

--- a/src/physics/types.rs
+++ b/src/physics/types.rs
@@ -132,6 +132,13 @@ pub struct Environment {
 }
 
 impl Environment {
+    pub fn new() -> Environment {
+        Environment {
+            bodies: vec![],
+            fields: vec![],
+        }
+    }
+
     pub fn update(&mut self) {
         for field in self.fields.iter() {
             let forces = field.forces(&self.bodies[..]);

--- a/src/physics/types.rs
+++ b/src/physics/types.rs
@@ -128,7 +128,7 @@ impl Field for BruteForceField {
 
 pub struct Environment {
     pub bodies: HashMap<u32, Body>,
-    pub fields: Vec<Field>,
+    pub fields: Vec<Box<Field>>,
 }
 
 impl Environment {

--- a/src/physics/types.rs
+++ b/src/physics/types.rs
@@ -1,5 +1,5 @@
 use geometry::types::{Point, Vector};
-use super::force::Gravity;
+use super::force::{Gravity, Attractor};
 use std::cmp::Eq;
 
 // Body //////////////////////////////////////////////////////////////////////
@@ -56,20 +56,15 @@ pub trait Field {
 
 pub struct BruteForceField {
     force: Gravity,
-    sun: Option<Body>,
+    sun: Option<Attractor>,
 }
 
 impl BruteForceField {
-    pub fn new(g: f32, solar_mass: f32, min_dist: f32) -> BruteForceField {
-        let sun = match solar_mass {
-            // TODO: tidy this up
-            x if x > 0.0 => Some(Body::new(0, solar_mass, Point::origin(), Vector::zero())),
-            _ => None,
-        };
+    pub fn new() -> BruteForceField {
 
         BruteForceField {
-            force: Gravity::new(g, min_dist),
-            sun,
+            force: Gravity::new(1.0, 4.0),
+            sun: Some(Attractor::new(10000.0, Point::origin(), 1.0, 4.0)),
         }
     }
 }
@@ -86,7 +81,7 @@ impl Field for BruteForceField {
             }
 
             if let Some(ref sun) = self.sun {
-                cumulative_force += self.force.between(body, &sun);
+                cumulative_force += sun.force(body);
             }
 
             result.push(cumulative_force);
@@ -107,7 +102,7 @@ pub struct Environment {
 
 impl Environment {
     pub fn new() -> Environment {
-        let field = BruteForceField::new(1.0, 10000.0, 4.0);
+        let field = BruteForceField::new();
         Environment {
             bodies: vec![],
             fields: vec![Box::from(field)],


### PR DESCRIPTION
## What's In This PR?

Force calculations have been refactored to allow a various implementations to be used in a modular way. A new `Field` trait defines an object that can calculate forces between a list of bodies. By implementing this trait, we can define an arbitrary force calculator. 

Note that a field calculates the force amongst a group of bodies. The actual force calculation on a single body or a pair of bodies has also been refactored out into a a new module `force`. This means we don't need to redefine the Newton's gravitation formula.

The old `Field` struct has been replaced with `BruteForceField` which implements the new `Field` trait. From this structure, it is clear to see that `BruteForceField` is just a single implementation of force calculation.

Lastly, the FFI has been updated to use an `Environment` object as the main entry point to the library (previously it was a `Field` object, however now fields are encapsulated in an environment).

## Edit

I've added some tests and I removed the `id` property from `Body` as it was now unnecessary.